### PR TITLE
Add ts-node (former typescript-node) for TS 1.6 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,8 +69,8 @@ const extensions = {
       module.install();
     }
   },
-  '.ts': ['typescript-node/register', 'typescript-register', 'typescript-require'],
-  '.tsx': ['typescript-node/register'],
+  '.ts': ['ts-node/register', 'typescript-node/register', 'typescript-register', 'typescript-require'],
+  '.tsx': ['ts-node/register', 'typescript-node/register'],
   '.wisp': 'wisp/engine/node',
   '.xml': 'require-xml',
   '.yaml': 'require-yaml',


### PR DESCRIPTION
typescript-node has been [renamed](https://github.com/blakeembrey/ts-node/issues/10) to ts-node. This PR adds support for the new module.