### PR TITLE
get ready for babel-register

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,19 @@ Map file types to modules which provide a [require.extensions] loader.
 {
   '.babel.js': [
     {
-      module: 'babel-core/register',
+      module: 'babel-register',
       register: function (module) {
         module({
           // register on .js extension due to https://github.com/joyent/node/blob/v0.12.0/lib/module.js#L353
           // which only captures the final extension (.babel.js -> .js)
+          extensions: '.js'
+        });
+      }
+    },
+    {
+      module: 'babel-core/register',
+      register: function (module) {
+        module({
           extensions: '.js'
         });
       }
@@ -47,6 +55,14 @@ Map file types to modules which provide a [require.extensions] loader.
   '.json': null,
   '.json5': 'json5/lib/require',
   '.jsx': [
+    {
+      module: 'babel-register',
+      register: function (module) {
+        module({
+          extensions: '.jsx'
+        });
+      }
+    },
     {
       module: 'babel-core/register',
       register: function (module) {

--- a/index.js
+++ b/index.js
@@ -1,11 +1,19 @@
 const extensions = {
   '.babel.js': [
     {
-      module: 'babel-core/register',
+      module: 'babel-register',
       register: function (module) {
         module({
           // register on .js extension due to https://github.com/joyent/node/blob/v0.12.0/lib/module.js#L353
           // which only captures the final extension (.babel.js -> .js)
+          extensions: '.js'
+        });
+      }
+    },
+    {
+      module: 'babel-core/register',
+      register: function (module) {
+        module({
           extensions: '.js'
         });
       }
@@ -33,6 +41,14 @@ const extensions = {
   '.json': null,
   '.json5': 'json5/lib/require',
   '.jsx': [
+    {
+      module: 'babel-register',
+      register: function (module) {
+        module({
+          extensions: '.jsx'
+        });
+      }
+    },
     {
       module: 'babel-core/register',
       register: function (module) {


### PR DESCRIPTION
Babel has just pushed a new `babel-register` package which is taking over from `babel-core/register`. The old version isn't deprecated just yet, but doesn't hurt to update early.