### PR TITLE
Support babel 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ Map file types to modules which provide a [require.extensions] loader.
 {
   '.babel.js': [
     {
+      module: '@babel/register',
+      register: function (module) {
+        module({
+          // register on .js extension due to https://github.com/joyent/node/blob/v0.12.0/lib/module.js#L353
+          // which only captures the final extension (.babel.js -> .js)
+          extensions: '.js'
+        });
+      }
+    },
+    {
       module: 'babel-register',
       register: function (module) {
         module({
@@ -56,6 +66,14 @@ Map file types to modules which provide a [require.extensions] loader.
   '.json': null,
   '.json5': 'json5/lib/require',
   '.jsx': [
+    {
+      module: '@babel/register',
+      register: function (module) {
+        module({
+          extensions: '.jsx'
+        });
+      }
+    },
     {
       module: 'babel-register',
       register: function (module) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,16 @@
 const extensions = {
   '.babel.js': [
     {
+      module: '@babel/register',
+      register: function (module) {
+        module({
+          // register on .js extension due to https://github.com/joyent/node/blob/v0.12.0/lib/module.js#L353
+          // which only captures the final extension (.babel.js -> .js)
+          extensions: '.js'
+        });
+      }
+    },
+    {
       module: 'babel-register',
       register: function (module) {
         module({

--- a/index.js
+++ b/index.js
@@ -53,6 +53,14 @@ const extensions = {
   '.json5': 'json5/lib/require',
   '.jsx': [
     {
+      module: '@babel/register',
+      register: function (module) {
+        module({
+          extensions: '.jsx'
+        });
+      }
+    },
+    {
       module: 'babel-register',
       register: function (module) {
         module({


### PR DESCRIPTION
Babel 7 renamed packages, all new packages are under the @babel scope. `@babel/register` is the new `babel-register`.

Babel 7 is currently in beta, but it'd be good to have support ready when it lands. Projects like webpack depend on interpret, having this will make the transition easier. (When upgrading to Babel 7 beta locally, this was the only issue in a Babel-heavy webpack/React project.)